### PR TITLE
simplify_debug_pr

### DIFF
--- a/src/function/algebra/rationalize.js
+++ b/src/function/algebra/rationalize.js
@@ -19,10 +19,14 @@ const dependencies = [
   '?bignumber',
   '?fraction',
   'mathWithTransform',
+  'matrix',
+  'AccessorNode',
   'ArrayNode',
   'ConstantNode',
   'OperatorNode',
   'FunctionNode',
+  'IndexNode',
+  'ObjectNode',
   'SymbolNode',
   'ParenthesisNode'
 ]
@@ -42,10 +46,14 @@ export const createRationalize = /* #__PURE__ */ factory(name, dependencies, ({
   fraction,
   bignumber,
   mathWithTransform,
+  matrix,
+  AccessorNode,
   ArrayNode,
   ConstantNode,
-  OperatorNode,
   FunctionNode,
+  IndexNode,
+  ObjectNode,
+  OperatorNode,
   SymbolNode,
   ParenthesisNode
 }) => {
@@ -53,12 +61,16 @@ export const createRationalize = /* #__PURE__ */ factory(name, dependencies, ({
     typed,
     config,
     mathWithTransform,
+    matrix,
     fraction,
     bignumber,
+    AccessorNode,
     ArrayNode,
     ConstantNode,
     OperatorNode,
     FunctionNode,
+    IndexNode,
+    ObjectNode,
     SymbolNode
   })
   const simplifyCore = createSimplifyCore({
@@ -69,9 +81,13 @@ export const createRationalize = /* #__PURE__ */ factory(name, dependencies, ({
     multiply,
     divide,
     pow,
+    AccessorNode,
+    ArrayNode,
     ConstantNode,
     OperatorNode,
     FunctionNode,
+    IndexNode,
+    ObjectNode,
     ParenthesisNode
   })
 

--- a/src/function/algebra/simplify.js
+++ b/src/function/algebra/simplify.js
@@ -22,9 +22,13 @@ const dependencies = [
   '?fraction',
   '?bignumber',
   'mathWithTransform',
+  'matrix',
+  'AccessorNode',
   'ArrayNode',
   'ConstantNode',
   'FunctionNode',
+  'IndexNode',
+  'ObjectNode',
   'OperatorNode',
   'ParenthesisNode',
   'SymbolNode'
@@ -45,9 +49,13 @@ export const createSimplify = /* #__PURE__ */ factory(name, dependencies, (
     fraction,
     bignumber,
     mathWithTransform,
+    matrix,
+    AccessorNode,
     ArrayNode,
     ConstantNode,
     FunctionNode,
+    IndexNode,
+    ObjectNode,
     OperatorNode,
     ParenthesisNode,
     SymbolNode
@@ -57,12 +65,16 @@ export const createSimplify = /* #__PURE__ */ factory(name, dependencies, (
     typed,
     config,
     mathWithTransform,
+    matrix,
     fraction,
     bignumber,
+    AccessorNode,
     ArrayNode,
     ConstantNode,
-    OperatorNode,
     FunctionNode,
+    IndexNode,
+    ObjectNode,
+    OperatorNode,
     SymbolNode
   })
   const simplifyCore = createSimplifyCore({
@@ -73,9 +85,13 @@ export const createSimplify = /* #__PURE__ */ factory(name, dependencies, (
     multiply,
     divide,
     pow,
+    AccessorNode,
+    ArrayNode,
     ConstantNode,
-    OperatorNode,
     FunctionNode,
+    IndexNode,
+    ObjectNode,
+    OperatorNode,
     ParenthesisNode
   })
   const resolve = createResolve({
@@ -412,6 +428,14 @@ export const createSimplify = /* #__PURE__ */ factory(name, dependencies, (
     return new SymbolNode('_p' + _lastsym++)
   }
 
+  function mapRule (nodes, rule) {
+    if (nodes) {
+      for (let i = 0; i < nodes.length; ++i) {
+        nodes[i] = applyRule(nodes[i], rule)
+      }
+    }
+  }
+
   /**
    * Returns a simplfied form of node, or the original node if no simplification was possible.
    *
@@ -426,17 +450,28 @@ export const createSimplify = /* #__PURE__ */ factory(name, dependencies, (
       let res = node
 
       // First replace our child nodes with their simplified versions
-      // If a child could not be simplified, the assignments will have
-      // no effect since the node is returned unchanged
+      // If a child could not be simplified, applying the rule to it
+      // will have no effect since the node is returned unchanged
       if (res instanceof OperatorNode || res instanceof FunctionNode) {
-        if (res.args) {
-          for (let i = 0; i < res.args.length; i++) {
-            res.args[i] = applyRule(res.args[i], rule)
-          }
-        }
+        mapRule(res.args, rule)
       } else if (res instanceof ParenthesisNode) {
         if (res.content) {
           res.content = applyRule(res.content, rule)
+        }
+      } else if (res instanceof ArrayNode) {
+        mapRule(res.items, rule)
+      } else if (res instanceof AccessorNode) {
+        if (res.object) {
+          res.object = applyRule(res.object, rule)
+        }
+        if (res.index) {
+          res.index = applyRule(res.index, rule)
+        }
+      } else if (res instanceof IndexNode) {
+        mapRule(res.dimensions, rule)
+      } else if (res instanceof ObjectNode) {
+        for (const prop in res.properties) {
+          res.properties[prop] = applyRule(res.properties[prop], rule)
         }
       }
 

--- a/src/function/algebra/simplify/simplifyConstant.js
+++ b/src/function/algebra/simplify/simplifyConstant.js
@@ -1,5 +1,5 @@
 // TODO this could be improved by simplifying seperated constants under associative and commutative operators
-import { isFraction, isNode, isOperatorNode } from '../../../utils/is.js'
+import { isFraction, isMatrix, isNode, isArrayNode, isConstantNode, isIndexNode, isObjectNode, isOperatorNode } from '../../../utils/is.js'
 import { factory } from '../../../utils/factory.js'
 import { createUtil } from './util.js'
 import { noBignumber, noFraction } from '../../../utils/noop.js'
@@ -9,12 +9,16 @@ const dependencies = [
   'typed',
   'config',
   'mathWithTransform',
+  'matrix',
   '?fraction',
   '?bignumber',
+  'AccessorNode',
   'ArrayNode',
   'ConstantNode',
-  'OperatorNode',
   'FunctionNode',
+  'IndexNode',
+  'ObjectNode',
+  'OperatorNode',
   'SymbolNode'
 ]
 
@@ -22,20 +26,35 @@ export const createSimplifyConstant = /* #__PURE__ */ factory(name, dependencies
   typed,
   config,
   mathWithTransform,
+  matrix,
   fraction,
   bignumber,
+  AccessorNode,
   ArrayNode,
   ConstantNode,
-  OperatorNode,
   FunctionNode,
+  IndexNode,
+  ObjectNode,
+  OperatorNode,
   SymbolNode
 }) => {
   const { isCommutative, isAssociative, allChildren, createMakeNodeFunction } =
     createUtil({ FunctionNode, OperatorNode, SymbolNode })
 
   function simplifyConstant (expr, options) {
-    const res = foldFraction(expr, options)
-    return isNode(res) ? res : _toNode(res)
+    return _ensureNode(foldFraction(expr, options))
+  }
+  function _removeFractions (thing) {
+    if (isFraction(thing)) {
+      return thing.valueOf()
+    }
+    if (thing instanceof Array) {
+      return thing.map(_removeFractions)
+    }
+    if (isMatrix(thing)) {
+      return matrix(_removeFractions(thing.valueOf()))
+    }
+    return thing
   }
 
   function _eval (fnname, args, options) {
@@ -43,12 +62,7 @@ export const createSimplifyConstant = /* #__PURE__ */ factory(name, dependencies
       return mathWithTransform[fnname].apply(null, args)
     } catch (ignore) {
       // sometimes the implicit type conversion causes the evaluation to fail, so we'll try again after removing Fractions
-      args = args.map(function (x) {
-        if (isFraction(x)) {
-          return x.valueOf()
-        }
-        return x
-      })
+      args = args.map(_removeFractions)
       return _toNumber(mathWithTransform[fnname].apply(null, args), options)
     }
   }
@@ -74,9 +88,16 @@ export const createSimplifyConstant = /* #__PURE__ */ factory(name, dependencies
       return new ConstantNode(s)
     },
     Matrix: function (m) {
-      return new ArrayNode(m._data.map(e => _toNode(e)))
+      return new ArrayNode(m.valueOf().map(e => _toNode(e)))
     }
   })
+
+  function _ensureNode (thing) {
+    if (isNode(thing)) {
+      return thing
+    }
+    return _toNode(thing)
+  }
 
   // convert a number to a fraction only if it can be expressed exactly,
   // and when both numerator and denominator are small enough
@@ -128,6 +149,12 @@ export const createSimplifyConstant = /* #__PURE__ */ factory(name, dependencies
         return s
       }
       return _exactFraction(s.re, options)
+    },
+    'Matrix, Object': function (s, options) {
+      return matrix(_exactFraction(s.valueOf()))
+    },
+    'Array, Object': function (s, options) {
+      return s.map(_exactFraction)
     }
   })
 
@@ -149,7 +176,84 @@ export const createSimplifyConstant = /* #__PURE__ */ factory(name, dependencies
     }
     return new OperatorNode('/', 'divide', [n, new ConstantNode(f.d)])
   }
-
+  /* Handles constant indexing of ArrayNodes, matrices, and ObjectNodes */
+  function _foldAccessor (obj, index, options) {
+    if (!isIndexNode(index)) { // don't know what to do with that...
+      return new AccessorNode(_ensureNode(obj), _ensureNode(index))
+    }
+    if (isArrayNode(obj) || isMatrix(obj)) {
+      const remainingDims = Array.from(index.dimensions)
+      /* We will resolve constant indices one at a time, looking
+       * just in the first or second dimensions because (a) arrays
+       * of more than two dimensions are likely rare, and (b) pulling
+       * out the third or higher dimension would be pretty intricate.
+       * The price is that we miss simplifying [..3d array][x,y,1]
+       */
+      while (remainingDims.length > 0) {
+        if (isConstantNode(remainingDims[0]) &&
+            typeof remainingDims[0].value !== 'string') {
+          const first = _toNumber(remainingDims.shift().value, options)
+          if (isArrayNode(obj)) {
+            obj = obj.items[first - 1]
+          } else { // matrix
+            obj = obj.valueOf()[first - 1]
+            if (obj instanceof Array) {
+              obj = matrix(obj)
+            }
+          }
+        } else if (remainingDims.length > 1 &&
+                   isConstantNode(remainingDims[1]) &&
+                   typeof remainingDims[1].value !== 'string') {
+          const second = _toNumber(remainingDims[1].value, options)
+          const tryItems = []
+          const fromItems = isArrayNode(obj) ? obj.items : obj.valueOf()
+          for (const item of fromItems) {
+            if (isArrayNode(item)) {
+              tryItems.push(item.items[second - 1])
+            } else if (isMatrix(obj)) {
+              tryItems.push(item[second - 1])
+            } else {
+              break
+            }
+          }
+          if (tryItems.length === fromItems.length) {
+            if (isArrayNode(obj)) {
+              obj = new ArrayNode(tryItems)
+            } else { // matrix
+              obj = matrix(tryItems)
+            }
+            remainingDims.splice(1, 1)
+          } else { // extracting slice along 2nd dimension failed, give up
+            break
+          }
+        } else { // neither 1st or 2nd dimension is constant, give up
+          break
+        }
+      }
+      if (remainingDims.length === index.dimensions.length) {
+        /* No successful constant indexing */
+        return new AccessorNode(_ensureNode(obj), index)
+      }
+      if (remainingDims.length > 0) {
+        /* Indexed some but not all dimensions */
+        index = new IndexNode(remainingDims)
+        return new AccessorNode(_ensureNode(obj), index)
+      }
+      /* All dimensions were constant, access completely resolved */
+      return obj
+    }
+    if (isObjectNode(obj) &&
+        index.dimensions.length === 1 &&
+        isConstantNode(index.dimensions[0])) {
+      const key = index.dimensions[0].value
+      if (key in obj.properties) {
+        return obj.properties[key]
+      }
+      return new ConstantNode() // undefined
+    }
+    /* Don't know how to index this sort of obj, at least not with this index */
+    return new AccessorNode(_ensureNode(obj), index)
+  }
   /*
    * Create a binary tree from a list of Fractions and Nodes.
    * Tries to fold Fractions by evaluating them until the first Node in the list is hit, so
@@ -199,20 +303,29 @@ export const createSimplifyConstant = /* #__PURE__ */ factory(name, dependencies
           // Process operators as OperatorNode
           const operatorFunctions = ['add', 'multiply']
           if (operatorFunctions.indexOf(node.name) === -1) {
-            let args = node.args.map(arg => foldFraction(arg, options))
+            const args = node.args.map(arg => foldFraction(arg, options))
 
             // If all args are numbers
             if (!args.some(isNode)) {
               try {
                 return _eval(node.name, args, options)
-              } catch (ignoreandcontine) {}
+              } catch (ignoreandcontinue) { }
+            }
+            // Size of a matrix does not depend on entries
+            if (node.name === 'size' &&
+                args.length === 1 &&
+                isArrayNode(args[0])) {
+              const sz = []
+              let section = args[0]
+              while (isArrayNode(section)) {
+                sz.push(section.items.length)
+                section = section.items[0]
+              }
+              return matrix(sz)
             }
 
             // Convert all args to nodes and construct a symbolic function call
-            args = args.map(function (arg) {
-              return isNode(arg) ? arg : _toNode(arg)
-            })
-            return new FunctionNode(node.name, args)
+            return new FunctionNode(node.name, args.map(_ensureNode))
           } else {
             // treat as operator
           }
@@ -272,17 +385,34 @@ export const createSimplifyConstant = /* #__PURE__ */ factory(name, dependencies
         return foldFraction(node.content, options)
       case 'AccessorNode':
         /* falls through */
-      case 'ArrayNode':
-        return node // FIXME: these two cases missing possible simplifications
+        return _foldAccessor(
+          foldFraction(node.object, options),
+          foldFraction(node.index, options),
+          options)
+      case 'ArrayNode': {
+        const foldItems = node.items.map(item => foldFraction(item, options))
+        if (foldItems.some(isNode)) {
+          return new ArrayNode(foldItems.map(_ensureNode))
+        }
+        /* All literals -- return a Matrix so we can operate on it */
+        return matrix(foldItems)
+      }
+      case 'IndexNode': {
+        return new IndexNode(
+          node.dimensions.map(n => simplifyConstant(n, options)))
+      }
+      case 'ObjectNode': {
+        const foldProps = {}
+        for (const prop in node.properties) {
+          foldProps[prop] = simplifyConstant(node.properties[prop], options)
+        }
+        return new ObjectNode(foldProps)
+      }
       case 'AssignmentNode':
         /* falls through */
       case 'BlockNode':
         /* falls through */
       case 'FunctionAssignmentNode':
-        /* falls through */
-      case 'IndexNode':
-        /* falls through */
-      case 'ObjectNode':
         /* falls through */
       case 'RangeNode':
         /* falls through */


### PR DESCRIPTION
## in this PR debug the error and fix it by: 
- Allow simplify to work in arrays, objects, and indexing Mostly ArrayNode, ObjectNode, AccessorNode, and IndexNode nodes are simply transparent to simplification -- they simply allow it to occur within subexpressions.
- This involves allowing ArrayNodes containing only constant entries
  to temporarily convert to Matrix type inside of simplifyConstant, so that
  function and operator calls can occur on them.

## how to run
- npm install
- npm run test